### PR TITLE
:recycle: Refactor exporting albums into archives

### DIFF
--- a/app/ControllerFunctions/ReadAccessFunctions.php
+++ b/app/ControllerFunctions/ReadAccessFunctions.php
@@ -55,7 +55,7 @@ class ReadAccessFunctions
             return 2;
         }
 
-        if ($album->password === '') {
+        if (empty($album->password)) {
             // access granted
             return 1;
         }

--- a/app/Http/Requests/ExportRequest.php
+++ b/app/Http/Requests/ExportRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Rules\AlbumExists;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExportRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->replace(['albumIDs' => \explode(',', $this->albumIDs)]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string>
+     */
+    public function rules(): array
+    {
+        return [
+            'albumIDs' => 'required|array',
+            'albumIDs.*' => new AlbumExists(),
+        ];
+    }
+}

--- a/app/ModelFunctions/AlbumActions/Cast.php
+++ b/app/ModelFunctions/AlbumActions/Cast.php
@@ -38,7 +38,7 @@ class Cast
             'max_takestamp' => $album->str_max_takestamp(),
 
             // Parse password
-            'password' => Helpers::str_of_bool($album->password !== ''),
+            'password' => Helpers::str_of_bool(!empty($album->password)),
             'license' => $album->get_license(),
 
             'thumbs' => [],

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -261,4 +261,30 @@ class Album extends Model
     {
         return \str_replace(Config::get('file.invalid_characters'), '', $this->title) ?: 'Untitled';
     }
+
+    public function getAvailablePhotos(): Builder
+    {
+        return Photo::set_order($this->get_photos());
+    }
+
+    public function canBeSeenBy(?User $user): bool
+    {
+        if ($this->public) {
+            return true;
+        }
+
+        if ($user && ($user->id === $this->owner_id || $user->isAdmin())) {
+            return true;
+        }
+
+        $isShared = $this->shared_with->map(function (User $user) {
+            return $user->id;
+        })->contains(\optional($user)->id);
+
+        if ($isShared) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Storage;
 
 /**
@@ -505,5 +506,10 @@ class Photo extends Model
     public function scopeOwnedBy(Builder $query, int $id)
     {
         return $id === 0 ? $query : $query->where('owner_id', '=', $id);
+    }
+
+    public function getArchiveTitle(): string
+    {
+        return \str_replace(Config::get('file.invalid_characters'), '', $this->title) ?: 'Untitled';
     }
 }

--- a/app/Models/SmartAlbums/PublicAlbum.php
+++ b/app/Models/SmartAlbums/PublicAlbum.php
@@ -6,6 +6,7 @@ namespace App\Models\SmartAlbums;
 
 use App\Models\Photo;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * App\Models\SmartAlbums\PublicAlbum.
@@ -37,5 +38,10 @@ class PublicAlbum extends SmartAlbum
         return Photo::public()->where(function ($q) {
             return $this->filter($q);
         });
+    }
+
+    public function getAvailablePhotos(): Builder
+    {
+        Photo::select_public(Photo::ownedBy(Auth::user()->id));
     }
 }

--- a/app/Models/SmartAlbums/RecentAlbum.php
+++ b/app/Models/SmartAlbums/RecentAlbum.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Models\SmartAlbums;
 
+use App\ModelFunctions\AlbumsFunctions;
 use App\Models\Configs;
 use App\Models\Photo;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * App\Models\SmartAlbums\RecentAlbum.
@@ -43,5 +46,16 @@ class RecentAlbum extends SmartAlbum
     public function is_public(): bool
     {
         return Configs::get_value('public_recent', '0') === '1';
+    }
+
+    public function getAvailablePhotos(): Builder
+    {
+        if (Auth::check() && (Auth::user()->isAdmin() || Auth::user()->upload)) {
+            return Photo::select_recent(Photo::ownedBy(Auth::user()->id));
+        }
+
+        $albumsFunctions = App::make(AlbumsFunctions::class);
+
+        return Photo::select_recent(Photo::whereIn('album_id', $albumsFunctions->getPublicAlbumsId()));
     }
 }

--- a/app/Models/SmartAlbums/StarredAlbum.php
+++ b/app/Models/SmartAlbums/StarredAlbum.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Models\SmartAlbums;
 
+use App\ModelFunctions\AlbumsFunctions;
 use App\Models\Configs;
 use App\Models\Photo;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * App\Models\SmartAlbums\StarredAlbum.
@@ -43,5 +46,16 @@ class StarredAlbum extends SmartAlbum
     public function is_public(): bool
     {
         return Configs::get_value('public_starred', '0') === '1';
+    }
+
+    public function getAvailablePhotos(): Builder
+    {
+        if (Auth::check() && (Auth::user()->isAdmin() || Auth::user()->upload)) {
+            return Photo::select_stars(Photo::ownedBy(Auth::user()->id));
+        }
+
+        $albumsFunctions = App::make(AlbumsFunctions::class);
+
+        return Photo::select_stars(Photo::whereIn('album_id', $albumsFunctions->getPublicAlbumsId()));
     }
 }

--- a/app/Models/SmartAlbums/UnsortedAlbum.php
+++ b/app/Models/SmartAlbums/UnsortedAlbum.php
@@ -6,6 +6,7 @@ namespace App\Models\SmartAlbums;
 
 use App\Models\Photo;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * App\Models\SmartAlbums\UnsortedAlbum.
@@ -29,6 +30,11 @@ class UnsortedAlbum extends SmartAlbum
     public function get_title(): string
     {
         return 'unsorted';
+    }
+
+    public function getAvailablePhotos(): Builder
+    {
+        return Photo::select_unsorted(Photo::ownedBy(Auth::user()->id));
     }
 
     public function get_photos(): Builder

--- a/app/Rules/AlbumExists.php
+++ b/app/Rules/AlbumExists.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Models\Album;
+use App\Services\AlbumFactory;
+use Illuminate\Contracts\Validation\Rule;
+
+class AlbumExists implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     */
+    public function passes($attribute, $value): bool
+    {
+        if (\array_key_exists($value, AlbumFactory::$albumMap)) {
+            return true;
+        }
+
+        return \optional(Album::find($value))->count() > 0;
+    }
+
+    public function message(): string
+    {
+        return 'The album :attribute does not exist.';
+    }
+}

--- a/app/Services/AlbumFactory.php
+++ b/app/Services/AlbumFactory.php
@@ -12,7 +12,7 @@ use App\Models\SmartAlbums\UnsortedAlbum;
 
 class AlbumFactory
 {
-    private static array $albumMap = [
+    public static array $albumMap = [
         StarredAlbum::ID => StarredAlbum::class,
         PublicAlbum::ID => PublicAlbum::class,
         RecentAlbum::ID => RecentAlbum::class,

--- a/app/Services/AlbumsPhotosService.php
+++ b/app/Services/AlbumsPhotosService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Album;
+use Illuminate\Support\Facades\Auth;
+
+class AlbumsPhotosService
+{
+    private AlbumFactory $albumFactory;
+
+    public function __construct(AlbumFactory $albumFactory)
+    {
+        $this->albumFactory = $albumFactory;
+    }
+
+    /**
+     * @param array<mixed> $albumIds
+     *
+     * @return array<string, array<string, array<string, string>>>
+     */
+    public function getAlbumsPhotos(array $albumIds): array
+    {
+        $albums = [];
+        $user = Auth::user();
+
+        foreach ($albumIds as $albumId) {
+            /** @var Album $album */
+            $album = $this->albumFactory->getAlbum($albumId);
+
+            // This might not be correct given the class that is aimed to be abstracted from Auth logic
+            // Maybe we need to change class name or move this somewhere else.
+            if (!$album->canBeSeenBy($user)) {
+                continue;
+            }
+
+            $albums[] = [
+                'album' => $album,
+                'content' => $this->getAlbumPhotos($album),
+            ];
+        }
+
+        return $albums;
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public function getAlbumPhotos(Album $album): array
+    {
+        $files = [];
+        $photos = $album->getAvailablePhotos()->get();
+
+        foreach ($photos as $photo) {
+            $files['photos'][] = $photo;
+        }
+
+        foreach ($album->children()->get() as $childAlbum) {
+            /** @var Album $childAlbum */
+            $files['children'][] = [
+                'album' => $childAlbum,
+                'content' => $this->getAlbumPhotos($childAlbum),
+            ];
+        }
+
+        return $files;
+    }
+}

--- a/app/Services/DownloadAlbumService.php
+++ b/app/Services/DownloadAlbumService.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Assets\Helpers;
+use App\Models\Album;
+use App\Models\Configs;
+use App\Models\Logs;
+use App\Models\Photo;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use ZipStream\Option\Archive;
+use ZipStream\ZipStream;
+
+class DownloadAlbumService
+{
+    /**
+     * @param array<string, array<string, mixed>> $albumsPhotos
+     */
+    public function handle(array $albumsPhotos): callable
+    {
+        return function () use ($albumsPhotos): void {
+            $this->makeArchive($albumsPhotos);
+        };
+    }
+
+    /**
+     * This method starts outputting Headers, just so you know.
+     *
+     * @param array<string, array<string, mixed>> $albumsPhotos
+     */
+    public function makeArchive(array $albumsPhotos): void
+    {
+        if (\count($albumsPhotos) === 0) {
+            return;
+        }
+
+        /* Extract this in archive factory */
+        $archive = new Archive();
+        $archive->setEnableZip64(Configs::get_value('zip64', '1') === '1');
+        $zip = new ZipStream(null, $archive);
+
+        $this->addFolders($albumsPhotos, $zip);
+
+        $zip->finish();
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $albumsPhotos
+     */
+    private function addFolders(array $albumsPhotos, ZipStream $zip, string $parentDir = ''): void
+    {
+        $folders = [];
+        foreach ($albumsPhotos as $albumPhotos) {
+            /** @var Album $album */
+            $album = $albumPhotos['album'];
+
+            if (!$album->isSmart() && !$album->public && (!Auth::check() || $album->owner_id !== Auth::user()->id)) {
+                continue;
+            }
+
+            $photos = $albumPhotos['content']['photos'];
+            $children = Arr::get($albumPhotos, 'content.children');
+
+            $folder = $this->getFolder($album, $folders, $parentDir);
+            $folders[] = $folder;
+
+            $this->addPhotos($photos, $album, $zip, $folder, $children);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $albumsPhotos
+     */
+    public function getArchiveTitle(array $albumsPhotos): string
+    {
+        $zipTitle = 'Albums';
+        if (\count($albumsPhotos) === 1) {
+            $album = $albumsPhotos[0]['album'];
+            $zipTitle = $album->getArchiveTitle();
+        }
+
+        return $zipTitle;
+    }
+
+    /**
+     * @param array<string> $dirs
+     */
+    private function getFolder(Album $album, array $dirs, string $parentDir): string
+    {
+        $dir = $album->getArchiveTitle() ?? 'Untitled';
+        $dir = $this->uniqueName($dir, \array_keys($dirs));
+        if ($parentDir !== '') {
+            $dir = $parentDir . '/' . $dir;
+        }
+
+        return $dir;
+    }
+
+    /**
+     * @param array<string> $fileNames
+     *
+     * @return array<string>
+     */
+    private function getPhotoFile(Photo $photo, array $fileNames): array
+    {
+        $isRaw = $photo->type === 'raw';
+
+        $prefix_url = $isRaw ? 'raw/' : 'big/';
+        $filePath = Storage::path($prefix_url . $photo->url);
+        // Check if readable
+        if (!@\is_readable($filePath)) {
+            Logs::error(__METHOD__, (string) __LINE__, 'Original photo missing: ' . $filePath);
+
+            return ['', ''];
+        }
+
+        // Get extension of image
+        $extension = Helpers::getExtension($filePath, false);
+
+        // Set title for photo
+        $title = $photo->getArchiveTitle();
+        $title .= ($isRaw ? '' : $extension);
+        $title = $this->uniqueName($title, $fileNames);
+
+        return [$filePath, $title];
+    }
+
+    /**
+     * @param array<string> $existingNames
+     */
+    private function uniqueName(string $givenName, array $existingNames): string
+    {
+        $i = 1;
+        $tmpName = $givenName;
+        $pos = \mb_strrpos($tmpName, '.') ?: \mb_strlen($tmpName);
+        while (\in_array($tmpName, $existingNames, true)) {
+            // Set new title for photo
+            $tmpName = \substr_replace($givenName, '-' . $i, $pos, 0);
+            ++$i;
+        }
+
+        return $tmpName;
+    }
+
+    /**
+     * @param array<Photo> $photos
+     * @param array<array<string, mixed>> $children
+     */
+    private function addPhotos(array $photos, Album $album, ZipStream $zip, string $folder, array $children): void
+    {
+        $files = [];
+        /** @var Photo $photo */
+        foreach ($photos as $photo) {
+            if ($album->isSmart() && !Auth::check() && $photo->album_id && !$photo->album->is_downloadable()) {
+                continue;
+            }
+
+            [$filePath, $title] = $this->getPhotoFile($photo, $files);
+
+            $zip->addFileFromPath($folder . '/' . $title, $filePath);
+        }
+
+        if ($children) {
+            $this->addFolders($children, $zip, $folder);
+        }
+    }
+}

--- a/ecs.yml
+++ b/ecs.yml
@@ -163,5 +163,7 @@ parameters:
             - 'app/Http/Middleware/VerifyCsrfToken.php'
             - 'app/Image/GdHandler.php'
             - 'app/Exceptions/Handler.php'
+        SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingNativeTypeHint:
+            - 'app/Rules/AlbumExists.php'
         Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff.Found:
             - 'config/*'

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,9 +23,9 @@ Route::get('/albums', 'AlbumsController@index');
 Route::get('/albums/position-data', 'AlbumsController@getPositionData');
 
 Route::middleware('read')->group(function (): void {
+    Route::get('/album/archive', 'AlbumController@export');
     Route::get('/album/{albumId}', 'AlbumController@show');
     Route::post('/album/{albumId}/position-data', 'AlbumController@showPositionData');
-    Route::post('/album/archive', 'AlbumController@getArchive');
 });
 
 /*
@@ -50,7 +50,7 @@ Route::post('/Album::delete', 'AlbumController@delete')->middleware('upload');
 Route::post('/Album::merge', 'AlbumController@merge')->middleware('upload');
 Route::post('/Album::move', 'AlbumController@move')->middleware('upload');
 Route::post('/Album::setLicense', 'AlbumController@setLicense')->middleware('upload');
-Route::get('/Album::getArchive', 'AlbumController@getArchive')->middleware('read');
+Route::get('/Album::getArchive', 'AlbumController@export')->middleware('read');
 
 Route::post('/Frame::getSettings', 'FrameController@getSettings');
 

--- a/tests/Unit/app/Services/AlbumsPhotosServiceTest.php
+++ b/tests/Unit/app/Services/AlbumsPhotosServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\app\Services;
+
+use App\Models\Album;
+use App\Models\Photo;
+use App\Models\User;
+use App\Services\AlbumFactory;
+use App\Services\AlbumsPhotosService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class AlbumsPhotosServiceTest extends TestCase
+{
+    public function testGetAlbumsPhotosThatCanBeSeen(): void
+    {
+        Auth::shouldReceive('user')->andReturn($this->createMock(User::class));
+        $builderMock = $this->createMock(Builder::class);
+        $builderMock->method('get')->willReturn([$this->createMock(Photo::class)]);
+        $albumMock = $this->createMock(Album::class);
+        $albumMock->method('canBeSeenBy')->willReturn(true);
+        $albumMock->method('getAvailablePhotos')->willReturn($builderMock);
+        $hasManyMock = $this->createMock(HasMany::class);
+        $hasManyMock->method('get')->willReturn([]);
+        $albumMock->method('children')->willReturn($hasManyMock);
+        $albumFactoryMock = $this->createMock(AlbumFactory::class);
+        $albumFactoryMock->method('getAlbum')->willReturn($albumMock);
+
+        $albumsPhotosService = new AlbumsPhotosService($albumFactoryMock);
+        $albums = $albumsPhotosService->getAlbumsPhotos([1]);
+
+        static::assertCount(1, $albums);
+        static::assertInstanceOf(Album::class, $albums[0]['album']);
+        static::assertArrayHasKey('photos', $albums[0]['content']);
+        static::assertArrayNotHasKey('children', $albums[0]['content']);
+        static::assertCount(1, $albums[0]['content']['photos']);
+        static::assertInstanceOf(Photo::class, $albums[0]['content']['photos'][0]);
+    }
+
+    public function testGetAlbumsPhotosThatCannotBeSeen(): void
+    {
+        Auth::shouldReceive('user')->andReturn($this->createMock(User::class));
+
+        $albumMock = $this->createMock(Album::class);
+        $albumMock->method('canBeSeenBy')->willReturn(false);
+
+        $albumFactoryMock = $this->createMock(AlbumFactory::class);
+        $albumFactoryMock->method('getAlbum')->willReturn($albumMock);
+
+        $albumsPhotosService = new AlbumsPhotosService($albumFactoryMock);
+        $albums = $albumsPhotosService->getAlbumsPhotos([1]);
+
+        static::assertCount(0, $albums);
+    }
+
+    public function testGetAlbumPhotosWithoutChildren()
+    {
+        $albumFactoryMock = $this->createMock(AlbumFactory::class);
+        $builderMock = $this->createMock(Builder::class);
+        $builderMock->method('get')->willReturn([$this->createMock(Photo::class)]);
+        $albumMock = $this->createMock(Album::class);
+        $albumMock->method('getAvailablePhotos')->willReturn($builderMock);
+        $hasManyMock = $this->createMock(HasMany::class);
+        $hasManyMock->method('get')->willReturn([]);
+        $albumMock->method('children')->willReturn($hasManyMock);
+
+        $albumsPhotosService = new AlbumsPhotosService($albumFactoryMock);
+        $files = $albumsPhotosService->getAlbumPhotos($albumMock);
+
+        static::assertArrayHasKey('photos', $files);
+        static::assertArrayNotHasKey('children', $files);
+        static::assertCount(1, $files['photos']);
+        static::assertInstanceOf(Photo::class, $files['photos'][0]);
+    }
+
+    public function testGetAlbumPhotosWithChildren()
+    {
+        $albumFactoryMock = $this->createMock(AlbumFactory::class);
+        $builderMock = $this->createMock(Builder::class);
+        $builderMock->method('get')->willReturn([$this->createMock(Photo::class)]);
+
+        $albumMock = $this->createMock(Album::class);
+        $albumMock->method('getAvailablePhotos')->willReturn($builderMock);
+
+        $childrenAlbumMock = $this->createMock(Album::class);
+        $childrenAlbumMock->method('getAvailablePhotos')->willReturn($builderMock);
+        $childrenHasManyMock = $this->createMock(HasMany::class);
+        $childrenHasManyMock->method('get')->willReturn([]);
+        $childrenAlbumMock->method('children')->willReturn($childrenHasManyMock);
+
+        $hasManyMock = $this->createMock(HasMany::class);
+        $hasManyMock->method('get')->willReturn([$childrenAlbumMock]);
+        $albumMock->method('children')->willReturn($hasManyMock);
+
+        $albumsPhotosService = new AlbumsPhotosService($albumFactoryMock);
+        $files = $albumsPhotosService->getAlbumPhotos($albumMock);
+
+        static::assertArrayHasKey('photos', $files);
+        static::assertArrayHasKey('children', $files);
+        static::assertCount(1, $files['photos']);
+        static::assertInstanceOf(Photo::class, $files['photos'][0]);
+        static::assertInstanceOf(Album::class, $files['children'][0]['album']);
+        static::assertArrayHasKey('photos', $files['children'][0]['content']);
+        static::assertArrayNotHasKey('children', $files['children'][0]['content']);
+    }
+
+    public function testGetAlbumPhotosWithoutAnyPhotos()
+    {
+        $albumFactoryMock = $this->createMock(AlbumFactory::class);
+        $builderMock = $this->createMock(Builder::class);
+        $builderMock->method('get')->willReturn([]);
+        $albumMock = $this->createMock(Album::class);
+        $albumMock->method('getAvailablePhotos')->willReturn($builderMock);
+        $hasManyMock = $this->createMock(HasMany::class);
+        $hasManyMock->method('get')->willReturn([]);
+        $albumMock->method('children')->willReturn($hasManyMock);
+
+        $albumsPhotosService = new AlbumsPhotosService($albumFactoryMock);
+        $files = $albumsPhotosService->getAlbumPhotos($albumMock);
+
+        static::assertArrayNotHasKey('photos', $files);
+        static::assertArrayNotHasKey('children', $files);
+        static::assertEmpty($files);
+    }
+}


### PR DESCRIPTION
Add rules and requests for download that suites better
laravel way.
Break down into different services classes the logic of
gathering photos by albums and compressing them into an
archive.

Fix #28 